### PR TITLE
fixed duplicated hanlders

### DIFF
--- a/scalex/function.py
+++ b/scalex/function.py
@@ -126,7 +126,7 @@ def SCALEX(
     
     outdir = outdir+'/'
     os.makedirs(outdir+'/checkpoint', exist_ok=True)
-    log = create_logger('', fh=outdir+'log.txt')
+    log = create_logger('SCALEX', fh=outdir+'log.txt', overwrite=True)
     if not projection:
         adata, trainloader, testloader = load_data(
             data_list, batch_categories, 

--- a/scalex/logger.py
+++ b/scalex/logger.py
@@ -10,9 +10,13 @@
 
 import logging
 
-def create_logger(name='', ch=True, fh='', levelname=logging.INFO):
+def create_logger(name='', ch=True, fh='', levelname=logging.INFO, overwrite=False):
     logger = logging.getLogger(name)
     logger.setLevel(levelname)
+    
+    if overwrite:
+        for h in logger.handlers:
+            logger.removeHandler(h)
     
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     # handler 


### PR DESCRIPTION
Bug: running `SCALEX` multiple times in a python kernel causes duplicated handlers. Fixed by resetting the handler list of the logger each time calling `create_logger`. 