### PR TITLE
fix: stop SingleCellDataset.__getitem_() from trying to use "toarray"…

### DIFF
--- a/scalex/data.py
+++ b/scalex/data.py
@@ -502,7 +502,10 @@ class SingleCellDataset(Dataset):
         return self.adata.X.shape[0]
     
     def __getitem__(self, idx):
-        x = self.adata.X[idx].toarray().squeeze()
+        if isinstance(self.adata.X[idx], np.ndarray):
+            x = self.adata.X[idx].squeeze()
+        else:
+            x = self.adata.X[idx].toarray().squeeze()
         domain_id = self.adata.obs['batch'].cat.codes[idx]
         return x, domain_id, idx
 

--- a/scalex/net/vae.py
+++ b/scalex/net/vae.py
@@ -11,9 +11,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
-from tqdm import tqdm
+from tqdm.autonotebook import trange
+from tqdm.contrib import tenumerate
 from collections import defaultdict
-import sys
 
 from .layer import *
 from .loss import *
@@ -155,9 +155,9 @@ class VAE(nn.Module):
         optim = torch.optim.Adam(self.parameters(), lr=lr, weight_decay=5e-4)
         n_epoch = int(np.ceil(max_iteration/len(dataloader)))
         
-        with tqdm(range(n_epoch), total=n_epoch, desc='Epochs') as tq:       
+        with trange(n_epoch, total=n_epoch, desc='Epochs') as tq:
             for epoch in tq:
-                tk0 = tqdm(enumerate(dataloader), total=len(dataloader), leave=False, desc='Iterations', disable=(not verbose))
+                tk0 = tenumerate(dataloader, total=len(dataloader), leave=False, desc='Iterations', disable=(not verbose))
                 epoch_loss = defaultdict(float)
                 for i, (x, y, idx) in tk0:
                     x, y = x.float().to(device), y.long().to(device)


### PR DESCRIPTION
… on ndarrays.

Cannot rely on the X member of an anndata object as being sparse; if loading an already processed object, the X member is most likely a numpy.ndarray, which is not sparse and does not have a `.toarray()` method.